### PR TITLE
Add English README and refactor variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Jira Sprint Summarizer
+
+This project contains two small scripts for generating release notes from Jira issues using either Google Gemini or OpenAI models. Both scripts fetch issues from Jira based on a JQL query and then ask the language model to produce a human‑friendly summary in Portuguese.
+
+## Requirements
+
+- Python 3.10+
+- Access to the required APIs (Jira, Google Gemini and/or OpenAI)
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Environment Variables
+
+Create a `.env` file with the following variables:
+
+- `JIRA_DOMAIN` – your Jira domain (without protocol)
+- `JIRA_EMAIL` – Jira account email
+- `JIRA_TOKEN` – Jira API token
+- `JIRA_PROJECT` – project key
+- `JIRA_SPRINT` – sprint identifier
+- `GEMINI_KEY` – API key for Google Gemini (used in `main.py`)
+- `GPT_KEY` – API key for OpenAI (used in `main_gpt.py`)
+
+## Usage
+
+Two entry points are provided:
+
+```bash
+python main.py      # uses Google Gemini
+python main_gpt.py  # uses OpenAI
+```
+
+Both commands will print the summary of the new version to the console.

--- a/main_gpt.py
+++ b/main_gpt.py
@@ -5,54 +5,54 @@ import requests
 from openai import OpenAI
 from requests.auth import HTTPBasicAuth
 from dotenv import load_dotenv
+
 load_dotenv(dotenv_path=".env")
 
-# CONFIGURAÇÕES JIRA
-JIRA_BASE_URL = f'https://{os.getenv('JIRA_DOMAIN')}.atlassian.net'
+# JIRA SETTINGS
+JIRA_BASE_URL = f"https://{os.getenv('JIRA_DOMAIN')}.atlassian.net"
 EMAIL = os.getenv("JIRA_EMAIL")
 API_TOKEN = os.getenv("JIRA_TOKEN")
-STATUS_COLUNA_NOVA_VERSAO = ["HM", "NOVA VERSÃO"]
-PROJETO = os.getenv("JIRA_PROJECT")
+NEW_VERSION_STATUS = ["HM", "NOVA VERSÃO"]
+PROJECT = os.getenv("JIRA_PROJECT")
 SPRINT = os.getenv("JIRA_SPRINT")
 
-# CONFIGURAÇÕES OPENAI
-# openai.api_key = os.getenv("GPT_KEY")  # Sua API Key da OpenAI
-MODEL = "gpt-4.1"  # ou gpt-3.5-turbo
-# Monte a lista de status com aspas
-status_str = ", ".join(f'"{s}"' for s in STATUS_COLUNA_NOVA_VERSAO)
-# MONTAGEM DA JQL
-JQL = f'project = {PROJETO} AND sprint = {SPRINT} AND status in ({status_str})'
+# OPENAI SETTINGS
+# openai.api_key = os.getenv("GPT_KEY")  # Your OpenAI API Key
+MODEL = "gpt-4.1"  # or gpt-3.5-turbo
+# Build list of status with quotes
+status_str = ", ".join(f'"{s}"' for s in NEW_VERSION_STATUS)
+# JQL ASSEMBLY
+JQL = f"project = {PROJECT} AND sprint = {SPRINT} AND status in ({status_str})"
 HEADERS = {"Accept": "application/json"}
 
 
-def buscar_issues(jql):
+def fetch_issues(jql: str):
     url = f"{JIRA_BASE_URL}/rest/api/3/search"
     params = {"jql": jql, "maxResults": 100}
 
     response = requests.get(
         url, headers=HEADERS, params=params, auth=HTTPBasicAuth(EMAIL, API_TOKEN)
     )
-    if response.status_code != 200:
-        raise Exception(f"Erro: {response.status_code} - {response.text}")
+    response.raise_for_status()
     return response.json()["issues"]
 
 
-def preparar_tarefas_para_llm(issues):
-    tarefas = []
+def prepare_tasks_for_llm(issues):
+    tasks = []
     for issue in issues:
         fields = issue["fields"]
-        tarefa = {
-            "chave": issue["key"],
-            "tipo": fields["issuetype"]["name"],
-            "resumo": fields["summary"],
+        task = {
+            "key": issue["key"],
+            "type": fields["issuetype"]["name"],
+            "summary": fields["summary"],
             "status": fields["status"]["name"]
         }
-        tarefas.append(tarefa)
-    return tarefas
+        tasks.append(task)
+    return tasks
 
 
-def gerar_explicacao_com_ia(tarefas):
-    conteudo_json = json.dumps(tarefas, indent=2, ensure_ascii=False)
+def generate_summary_with_ai(tasks):
+    json_content = json.dumps(tasks, indent=2, ensure_ascii=False)
 
     prompt = f"""
     Você é um assistente de produto. Receberá a resposta crua de uma API do Jira que contém tarefas de uma sprint.
@@ -60,10 +60,10 @@ def gerar_explicacao_com_ia(tarefas):
     Seu objetivo é ler o JSON e escrever um resumo claro e objetivo do que está sendo lançado nesta versão. Explique agrupando por tipo (bugs, histórias, tarefas técnicas, etc) e escreva em português.
 
     JSON da API Jira:
-    {conteudo_json}
+    {json_content}
         """
 
-    client = OpenAI(api_key=os.getenv("GPT_KEY"))  # sua chave aqui
+    client = OpenAI(api_key=os.getenv("GPT_KEY"))  # your key here
 
     response = client.chat.completions.create(
         model=MODEL,
@@ -77,9 +77,8 @@ def gerar_explicacao_com_ia(tarefas):
 
 
 if __name__ == "__main__":
-    issues = buscar_issues(JQL)
-    tarefas = preparar_tarefas_para_llm(issues)
-    # print(tarefas)
-    explicacao = gerar_explicacao_com_ia(tarefas)
+    issues = fetch_issues(JQL)
+    tasks = prepare_tasks_for_llm(issues)
+    summary = generate_summary_with_ai(tasks)
     print("\n📦 EXPLICAÇÃO DA NOVA VERSÃO:\n")
-    print(explicacao)
+    print(summary)


### PR DESCRIPTION
## Summary
- translate variable names to English in both scripts
- drop unused imports and improve HTTP error handling
- create README with setup and usage instructions

## Testing
- `python -m py_compile main.py main_gpt.py`

------
https://chatgpt.com/codex/tasks/task_e_6883ddfc586c832d8101addc1be6fec8